### PR TITLE
Title manager: Prevent deleting nand title by default (with a toggle); Remove useless nand options

### DIFF
--- a/source/fbi/titles.c
+++ b/source/fbi/titles.c
@@ -85,13 +85,12 @@ static void titles_action_update(ui_view* view, void* data, linked_list* items, 
         if(!info->twl) {
             linked_list_add(items, &extract_smdh);
 
-            if(info->mediaType != MEDIATYPE_GAME_CARD) {
-                linked_list_add(items, &import_seed);
+            if(info->mediaType != MEDIATYPE_NAND) {
+                linked_list_add(items, &browse_save_data);
             }
 
-            linked_list_add(items, &browse_save_data);
-
-            if(info->mediaType != MEDIATYPE_GAME_CARD) {
+            if(info->mediaType != MEDIATYPE_GAME_CARD && info->mediaType != MEDIATYPE_NAND) {
+                linked_list_add(items, &import_seed);
                 linked_list_add(items, &import_secure_value);
                 linked_list_add(items, &export_secure_value);
                 linked_list_add(items, &delete_secure_value);


### PR DESCRIPTION
There's a issue going on for a while where people brick their consoles by deleting random nand titles from FBI.
This PR tries to fix this by not showing the delete option, and add a toggle for it in the options menu (saying to be careful, so users should be warned.)

There's also a other issue where "import seed", secure value related options and "browse savedata" were shown for nand title; which don't work since NAND titles work differently/do not use these.
I just hidden these options since they're useless.